### PR TITLE
DO NOT MERGE - Remove support for Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       _JAVA_OPTIONS: "-Xms512m -Xmx1g"
     working_directory: ~/workspace
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - restore_cache:
@@ -40,7 +40,7 @@ jobs:
       _JAVA_OPTIONS: "-Xms512m -Xmx1g"
     working_directory: ~/workspace
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - restore_cache:
@@ -63,7 +63,7 @@ jobs:
   publish:
     working_directory: ~/workspace
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - restore_cache:

--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: microsoft
           cache: gradle
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-ver: [11, 17]
+        java-ver: [17]
         java-dist: ['microsoft', 'temurin']
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-ver: [11, 17]
+        java-ver: [17]
         java-dist: ['microsoft', 'temurin']
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-ver: [11]
+        java-ver: [17]
         java-dist: ['temurin']
         hw_platform: ['s390x']
     runs-on: ubuntu-latest
@@ -78,4 +78,4 @@ jobs:
             --name qemu-cross-${{ matrix.hw_platform }} \
             --mount type=bind,source=${PWD},target=/workspace \
             --workdir /workspace \
-            ${{matrix.hw_platform}}/eclipse-temurin:11-jdk /bin/sh -c "uname -a; ./gradlew --no-daemon -PmaxParallelForks=1 build"
+            ${{matrix.hw_platform}}/eclipse-temurin:${{matrix.java-ver}}-jdk /bin/sh -c "uname -a; ./gradlew --no-daemon -PmaxParallelForks=1 build"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Cruise Control for Apache Kafka
 * The `kafka_2_0_to_2_3` and `kafka_0_11_and_1_0` branches compile with `Scala 2.11`.
 * The branch `migrate_to_kafka_2_4` compiles with `Scala 2.12`.
 * The branch `migrate_to_kafka_2_5` compile with `Scala 2.13`.
-* This project requires Java 11, also compatible with Java 17.
+* This project requires Java 17.
 
 #### Known Compatibility Issues ####
 * Support for Apache Kafka `2.0`, `2.1`, `2.2`, and `2.3` requires [KAFKA-8875](https://issues.apache.org/jira/browse/KAFKA-8875) hotfix.
@@ -77,7 +77,7 @@ Cruise Control for Apache Kafka
         && git tag -a 0.1.10 -m "Init local version."`
 1. This step is required if `CruiseControlMetricsReporter` is used for metrics collection (i.e. the default for Cruise
 Control). The metrics reporter periodically samples the Kafka raw metrics on the broker and sends them to a Kafka topic.
-    * `./gradlew jar` (Note: This project requires Java 11 or 17)
+    * `./gradlew jar` (Note: This project requires Java 17)
     * Copy `./cruise-control-metrics-reporter/build/libs/cruise-control-metrics-reporter-A.B.C.jar` (Where `A.B.C` is
     the version of the Cruise Control) to your Kafka server dependency jar folder. For Apache Kafka, the folder would
     be `core/build/dependant-libs-SCALA_VERSION/` (for a Kafka source checkout) or `libs/` (for a Kafka release download).

--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,8 @@ subprojects {
   apply plugin: "com.github.spotbugs"
   apply plugin: 'jacoco'
 
-  // This project requires Java 11
-  sourceCompatibility = JavaVersion.VERSION_11
+  // This project requires Java 17
+  sourceCompatibility = JavaVersion.VERSION_17
 
   task sourcesJar(type: Jar, dependsOn: classes) {
     archiveClassifier.set("sources")


### PR DESCRIPTION
1. Why: Jetty 12 requires a minimum of Java 17, so Java 11 must be dropped to facilitate this upgrade. The current version of Jetty in cruise-control is 9.4.56.v20240826. This version contains two CVEs CVE-2024-13009 - patched in 9.4.57.v20241219
CVE-2024-6763 - patched in 12.0.12
So, Jetty 12 is need to patch CVE-2024-6763.

2. What: Remove support support for Java 11
Raise minimum JDK to 17 in builds, docs, and workflows

- [x] refactor
