### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -2,6 +2,9 @@ name: Artifactory
 
 on:
   workflow_dispatch: # manual trigger
+  push:
+    tags:
+      - '*'
   #release:
   #  types: [published]
 
@@ -21,5 +24,8 @@ jobs:
           cache: gradle
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0
       - name: publish
+        env:
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_KEY: ${{ secrets.ARTIFACTORY_KEY }}
         run: |
           ./gradlew :artifactoryPublish :cruise-control:artifactoryPublish :cruise-control-core:artifactoryPublish :cruise-control-metrics-reporter:artifactoryPublish

--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # manual trigger
   push:
     tags:
-      - '2.5.146-est-[0-9]+'
+      - '2.5.146-est[-]?[0-9]*'
   #release:
   #  types: [published]
 

--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # manual trigger
   push:
     tags:
-      - '2.5.146-est[-]?[0-9]*'
+      - '2.5.146-est-*'
   #release:
   #  types: [published]
 

--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # manual trigger
   push:
     tags:
-      - '*'
+      - '2.5.146-est-[0-9]+'
   #release:
   #  types: [published]
 
@@ -13,15 +13,15 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: 17
           distribution: microsoft
           cache: gradle
-      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: gradle build
         run: ./gradlew --no-daemon -PmaxParallelForks=1 build
 
@@ -30,15 +30,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: 17
           distribution: microsoft
           cache: gradle
-      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: gradle integration test
         run: ./gradlew --no-daemon -PmaxParallelForks=1 clean integrationTest
 
@@ -48,15 +48,15 @@ jobs:
     needs: integration-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: 17
           distribution: microsoft
           cache: gradle
-      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: publish
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}

--- a/.github/workflows/artifactory.yaml
+++ b/.github/workflows/artifactory.yaml
@@ -9,9 +9,43 @@ on:
   #  types: [published]
 
 jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so gradle doesn't fail traversing the history
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: microsoft
+          cache: gradle
+      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - name: gradle build
+        run: ./gradlew --no-daemon -PmaxParallelForks=1 build
+
+  integration-test:
+    name: integration-test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so gradle doesn't fail traversing the history
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: microsoft
+          cache: gradle
+      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - name: gradle integration test
+        run: ./gradlew --no-daemon -PmaxParallelForks=1 clean integrationTest
+
   publish:
     # if: startsWith(github.event.ref, 'release/')
     name: publish
+    needs: integration-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,16 +20,16 @@ jobs:
         java-ver: [17]
         java-dist: ['microsoft', 'temurin']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: ${{ matrix.java-ver }}
           distribution: ${{ matrix.java-dist }}
           cache: gradle
       # see: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: gradle javadoc
         run: ./gradlew --no-daemon clean javadoc
       - name: gradle static analysis
@@ -46,16 +46,16 @@ jobs:
         java-ver: [17]
         java-dist: ['microsoft', 'temurin']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: ${{ matrix.java-ver }}
           distribution: ${{ matrix.java-dist }}
           cache: gradle
       # see: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-      - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: gradle integration test
         run: ./gradlew --no-daemon -PmaxParallelForks=1 clean integrationTest
 
@@ -69,7 +69,7 @@ jobs:
         hw_platform: ['s390x']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # so gradle doesn't fail traversing the history
       - continue-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['main']
+    branches: ['main', '2.5.*']
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -30,6 +30,10 @@ jobs:
           cache: gradle
       # see: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - uses: gradle/actions/setup-gradle@v4 # v4.0.0
+      - name: gradle javadoc
+        run: ./gradlew --no-daemon clean javadoc
+      - name: gradle static analysis
+        run: ./gradlew --max-workers=1 --no-daemon analyze
       - name: gradle build
         run: ./gradlew --no-daemon -PmaxParallelForks=1 build
 

--- a/build.gradle
+++ b/build.gradle
@@ -510,9 +510,9 @@ project(':cruise-control-metrics-reporter') {
 
 artifactoryPublish.skip = true
 artifactory {
-  contextUrl = 'https://linkedin.jfrog.io/linkedin'
+  contextUrl = 'https://artifactory.nordix.org/artifactory'
   publish {
-    repoKey = 'cruise-control'
+    repoKey = 'allies-mvn'
     username = System.getenv('ARTIFACTORY_USER')
     password = System.getenv('ARTIFACTORY_KEY')
 


### PR DESCRIPTION
- Updated build.gradle artifactory URL and repo key 
- Added tag push trigger to artifactory.yaml for automated publishing on tag push
- Added secrets (ARTIFACTORY_USER, ARTIFACTORY_KEY) as env vars to the publish step
- Gated publish behind build and integration tests (build -> integration-test -> publish), replicating CircleCI's release safety
- Added 2.5.* to CI push branch triggers
- Added javadoc and static analysis steps to CI for parity with CircleCI
- CircleCI config not removed yet. Kept as reference for now.